### PR TITLE
small cosmetic change to main.css

### DIFF
--- a/assets/css/base/main.css
+++ b/assets/css/base/main.css
@@ -169,7 +169,7 @@ a:after {
     display: block;
     width: 100%;
     height: 34px;
-    padding: 13px 18px;
+   /* padding: 13px 18px; */
     font-size: 20px;
     line-height: 1.428571429;
     color: #333;


### PR DESCRIPTION
In .form-control, I removed "padding: 13px 18px" by commenting it out because it would not appear to display correctly in the browser. (tested on Firefox and Opera).  Half of the pre-filled text was not visible, nor was what I typed in.  This change corrected it.